### PR TITLE
 arm: Allow disabling PIE for dynamically linked executables

### DIFF
--- a/core/definitions.mk
+++ b/core/definitions.mk
@@ -1875,8 +1875,14 @@ endef
 ## Commands for running gcc to link an executable
 ###########################################################
 
+ifeq ($(TARGET_DISABLE_ARM_PIE),true)
+   PIE_EXECUTABLE_TRANSFORM :=
+else
+   PIE_EXECUTABLE_TRANSFORM := -pie
+endif
+
 define transform-o-to-executable-inner
-$(hide) $(PRIVATE_CXX) -pie \
+$(hide) $(PRIVATE_CXX) $(PIE_EXECUTABLE_TRANSFORM) \
 	-nostdlib -Bdynamic \
 	-Wl,-dynamic-linker,$(PRIVATE_LINKER) \
 	-Wl,--gc-sections \
@@ -1956,7 +1962,8 @@ endef
 ifdef BUILD_HOST_static
 HOST_FPIE_FLAGS :=
 else
-HOST_FPIE_FLAGS := -pie
+HOST_FPIE_FLAGS := $(PIE_EXECUTABLE_TRANSFORM)
+
 # Force the correct entry point to workaround a bug in binutils that manifests with -pie
 ifeq ($(HOST_CROSS_OS),windows)
 HOST_CROSS_FPIE_FLAGS += -Wl,-e_mainCRTStartup


### PR DESCRIPTION
PIE can and does break some binaries that were built without it,
resulting in relocation-related issues (addressing memory
wrongly assumed to be at a fixed position).

Use this as a last resort measure for compatibility with pre-JB
binary blobs, and only if confirmed to fix a broken executable.
If you're not sure, do NOT enable this on a device.

Change-Id: I3b7001e682a6f7a845e62278fe2afa9ccf5552a4